### PR TITLE
Support for private repos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "async-fs",
+ "base64 0.21.4",
  "chrono",
  "derive_builder",
  "eyre",
@@ -2345,6 +2346,7 @@ dependencies = [
  "once_cell",
  "path-absolutize",
  "rayon",
+ "secrecy",
  "serde",
  "serde_json",
  "simple-eyre",

--- a/crates/diffbot_lib/Cargo.toml
+++ b/crates/diffbot_lib/Cargo.toml
@@ -26,3 +26,4 @@ flume = "0.11.0"
 actix-web = "4.4.0"
 
 async-fs = "1.6.0"
+base64 = "0.21.4"

--- a/crates/mapdiffbot2/Cargo.toml
+++ b/crates/mapdiffbot2/Cargo.toml
@@ -39,6 +39,7 @@ tokio = { version = "1.32.0", features = ["io-util", "rt"] }
 
 mysql_async = "0.32.2"
 time = "0.3.28"
+secrecy = "0.8.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.5.4"

--- a/crates/mapdiffbot2/src/git_operations.rs
+++ b/crates/mapdiffbot2/src/git_operations.rs
@@ -1,8 +1,7 @@
 use eyre::{Context, Result};
-use secrecy::{Secret, ExposeSecret};
 use std::path::Path;
 
-use git2::{build::{CheckoutBuilder, RepoBuilder}, FetchOptions, Repository, RemoteCallbacks, Cred};
+use git2::{build::CheckoutBuilder, FetchOptions, Repository};
 
 pub fn fetch_and_get_branches<'a>(
     base_sha: &str,
@@ -10,23 +9,23 @@ pub fn fetch_and_get_branches<'a>(
     repo: &'a git2::Repository,
     head_branch_name: &str,
     base_branch_name: &str,
-    repo_token: Secret<String>,
 ) -> Result<(git2::Reference<'a>, git2::Reference<'a>)> {
     let base_id = git2::Oid::from_str(base_sha).wrap_err("Parsing base sha")?;
     let head_id = git2::Oid::from_str(head_sha).wrap_err("Parsing head sha")?;
 
     let mut remote = repo.find_remote("origin")?;
 
-    let mut fetch_options = create_fetch_options_for_token(repo_token);
-    fetch_options.prune(git2::FetchPrune::On);
+    remote
+        .connect(git2::Direction::Fetch)
+        .wrap_err("Connecting to remote")?;
 
     remote
         .fetch(
-            &[base_branch_name],
-            Some(&mut fetch_options),
+            &[base_branch_name, head_branch_name],
+            Some(FetchOptions::new().prune(git2::FetchPrune::On)),
             None,
         )
-        .wrap_err("Fetching base")?;
+        .wrap_err("Fetching base and head")?;
     let fetch_head = repo
         .find_reference("FETCH_HEAD")
         .wrap_err("Getting FETCH_HEAD")?;
@@ -67,14 +66,6 @@ pub fn fetch_and_get_branches<'a>(
     let base_branch = repo
         .resolve_reference_from_short_name(base_branch_name)
         .wrap_err("Getting the base reference")?;
-
-    remote
-        .fetch(
-            &[head_branch_name],
-            Some(&mut fetch_options),
-            None,
-        )
-        .wrap_err("Fetching head")?;
 
     let fetch_head = repo
         .find_reference("FETCH_HEAD")
@@ -177,34 +168,7 @@ pub fn with_checkout<T>(
     f()
 }
 
-fn create_fetch_options_for_token(repo_token: Secret<String>) -> FetchOptions<'static>{
-    let mut callbacks = RemoteCallbacks::new();
-    callbacks.credentials(move |_url, _username_from_url, _allowed_types| {
-        Cred::userpass_plaintext(repo_token.expose_secret(), "")
-    });
-
-    let mut fetch_options = git2::FetchOptions::new();
-    fetch_options.remote_callbacks(callbacks);
-    fetch_options
-}
-
-pub fn clone_repo(url: &str, dir: &Path, repo_token: Secret<String>) -> Result<()> {
-    let mut builder = RepoBuilder::new();
-    builder.fetch_options(create_fetch_options_for_token(repo_token));
-
-    builder.clone(url, dir).wrap_err("Cloning repo")?;
+pub fn clone_repo(url: &str, dir: &Path) -> Result<()> {
+    git2::Repository::clone(url, dir.as_os_str()).wrap_err("Cloning repo")?;
     Ok(())
 }
-
-/* local testing
-#[test]
-fn test_private_clone(){
-    clone_repo("https://github.com/Cyberboss/tgstation-private-test", &Path::new("S:/garbage/tgtest"), Secret::new("lol".to_string())).unwrap();
-}
-
-#[test]
-fn test_private_fetch(){
-    let repo = git2::Repository::open("S:/garbage/tgtest").unwrap();
-    fetch_and_get_branches("140c79189849ea616f09b3484f8930211d3705cd", "a34219208f6526d01d88c9fe02cc08554fe29dda", &repo, "TestPRForMDB", "master", Secret::new("lol".to_string())).unwrap();
-}
- */

--- a/crates/mapdiffbot2/src/runner.rs
+++ b/crates/mapdiffbot2/src/runner.rs
@@ -116,7 +116,7 @@ async fn job_handler(name: &str, job: Job, blob_client: Azure) {
 
     let output = actix_web::rt::time::timeout(
         Duration::from_secs(7200),
-        actix_web::rt::task::spawn_blocking(move || do_job(job, blob_client)),
+        do_job(job, blob_client),
     )
     .await;
 
@@ -135,19 +135,6 @@ async fn job_handler(name: &str, job: Job, blob_client: Azure) {
         output.unwrap()
     };
 
-    if let Err(e) = output {
-        let fuckup = match e.try_into_panic() {
-            Ok(panic) => {
-                format!("{panic:#?}")
-            }
-            Err(e) => e.to_string(),
-        };
-        tracing::error!("Join Handle error: {fuckup}");
-        let _ = check_run.mark_failed(&fuckup).await;
-        return;
-    }
-
-    let output = output.unwrap();
     if let Err(e) = output {
         let fuckup = format!("{e:?}");
         tracing::error!("Other rendering error: {fuckup}");

--- a/crates/mapdiffbot2/src/runner.rs
+++ b/crates/mapdiffbot2/src/runner.rs
@@ -116,7 +116,7 @@ async fn job_handler(name: &str, job: Job, blob_client: Azure) {
 
     let output = actix_web::rt::time::timeout(
         Duration::from_secs(7200),
-        do_job(job, blob_client),
+        actix_web::rt::task::spawn_blocking(move || do_job(job, blob_client)),
     )
     .await;
 
@@ -135,6 +135,19 @@ async fn job_handler(name: &str, job: Job, blob_client: Azure) {
         output.unwrap()
     };
 
+    if let Err(e) = output {
+        let fuckup = match e.try_into_panic() {
+            Ok(panic) => {
+                format!("{panic:#?}")
+            }
+            Err(e) => e.to_string(),
+        };
+        tracing::error!("Join Handle error: {fuckup}");
+        let _ = check_run.mark_failed(&fuckup).await;
+        return;
+    }
+
+    let output = output.unwrap();
     if let Err(e) = output {
         let fuckup = format!("{e:?}");
         tracing::error!("Other rendering error: {fuckup}");


### PR DESCRIPTION
- Use GitHub API for downloading files.
- Use installation token when cloning and fetching repositories.
- Remove unused function.

Untested, tell me how.

Closes #26 