### PR TITLE
Massively improve performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,6 +1664,7 @@ dependencies = [
  "eyre",
  "flume",
  "hashbrown 0.15.5",
+ "indexmap",
  "jsonwebtoken",
  "mysql_async",
  "octocrab",

--- a/crates/icondiffbot2/Cargo.toml
+++ b/crates/icondiffbot2/Cargo.toml
@@ -26,6 +26,7 @@ time = "0.3.41"
 secrecy = "0.10.3"
 percent-encoding = "2.3.2"
 dashmap = "6.1.0"
+indexmap = { version = "2.10.0", features = ["rayon"] }
 
 actix-web = "4.11.0"
 actix-files = "0.6.6"

--- a/crates/icondiffbot2/src/job_processor.rs
+++ b/crates/icondiffbot2/src/job_processor.rs
@@ -16,7 +16,7 @@ use std::{
     path::Path,
 };
 
-#[tracing::instrument]
+#[tracing::instrument(skip_all)]
 pub fn do_job(job: Job, client: reqwest::Client) -> Result<CheckOutputs> {
     let handle = actix_web::rt::Runtime::new()?;
 
@@ -46,7 +46,7 @@ pub fn do_job(job: Job, client: reqwest::Client) -> Result<CheckOutputs> {
     map.build()
 }
 
-#[tracing::instrument]
+#[tracing::instrument(skip_all)]
 fn render(
     job: &Job,
     diff: (Result<Option<IconFileWithName>>, Option<IconFileWithName>),
@@ -281,7 +281,7 @@ fn render(
     }
 }
 
-#[tracing::instrument]
+#[tracing::instrument(skip_all)]
 fn render_state<'a, S: AsRef<str> + std::fmt::Debug>(
     prefix: S,
     target: &IconFileWithName,
@@ -333,7 +333,7 @@ fn render_state<'a, S: AsRef<str> + std::fmt::Debug>(
     Ok(((index, state.name.clone()), url))
 }
 
-#[tracing::instrument]
+#[tracing::instrument(skip_all)]
 fn full_render(job: &Job, target: &IconFileWithName) -> Result<Vec<((usize, String), String)>> {
     let icon = &target.icon;
 
@@ -344,7 +344,7 @@ fn full_render(job: &Job, target: &IconFileWithName) -> Result<Vec<((usize, Stri
     let vec: Vec<((usize, String), String)> = icon
         .metadata
         .states
-        .values()
+        .par_values()
         .flat_map(|vec| {
             vec.iter()
                 .enumerate()


### PR DESCRIPTION
This fixes two problems that were slowing IDB down a ton:
1. tracing::instrument by default calls Debug::fmt on each argument each time a function is called - this was the main issue for IDB, as it has functions taking entire DMIs as arguments, which have default Debug implementations that write *every byte*
2. https://github.com/spacestation13/BYONDDiffBots/pull/40/files removed par_values on `fn full_render()`, which meant that full renders (new file, deleted file) were creating states serially. This happened because `IndexMap::par_value` is locked behind a feature flag that we at some point stopped enabling, yay for transitive feature flags.

Profile captured over the first 1000 images generated by https://github.com/tigercat2000/IconDiffBot2-test/pull/22

Profile overview before:
![https://files.catbox.moe/sswsdu.png](https://files.catbox.moe/sswsdu.png)

Profile overview after:
![https://files.catbox.moe/qmaqeb.png](https://files.catbox.moe/qmaqeb.png)

Main difference is that the tokio-runtime-worker thread is no longer pegged at 99% CPU the entire time.